### PR TITLE
missing parameter

### DIFF
--- a/intro-neural-networks/student-admissions/StudentAdmissions.ipynb
+++ b/intro-neural-networks/student-admissions/StudentAdmissions.ipynb
@@ -303,7 +303,7 @@
     "            error = error_formula(y, output)\n",
     "\n",
     "            # The error term\n",
-    "            error_term = error_term_formula(y, output)\n",
+    "            error_term = error_term_formula(x, y, output)\n",
     "\n",
     "            # The gradient descent step, the error times the gradient times the inputs\n",
     "            del_w += error_term * x\n",


### PR DESCRIPTION
Parameter x is missing from `error_term_formula` function in train_nn() function.